### PR TITLE
use pre built image by default in docker-compose

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -17,7 +17,7 @@ services:
 
   app:
     container_name: mealplan
-    image: ghcr.io/flecmart/mealplan
+    build: app
     restart: always
     env_file: environment.conf
     ports:


### PR DESCRIPTION
change docker-compose to use image built in github actions

- faster docker-compose up
- reusable images of different build versions